### PR TITLE
CI: Robust service account secrets for transparency updater

### DIFF
--- a/.github/workflows/update-transparency.yml
+++ b/.github/workflows/update-transparency.yml
@@ -23,8 +23,20 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Prepare service account (raw JSON)
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT}" ]; then
+            echo "Writing service account to runner temp..."
+            printf "%s" "${FIREBASE_SERVICE_ACCOUNT}" > "$RUNNER_TEMP/sa.json"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+          else
+            echo "No raw JSON secret provided; relying on B64 or ADC."
+          fi
+
       - name: Run transparency update
         env:
           FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
         run: node scripts/ops/update-transparency.mjs
-


### PR DESCRIPTION
- Accepts FIREBASE_SERVICE_ACCOUNT (raw JSON) and writes it to a temp file, exporting GOOGLE_APPLICATION_CREDENTIALS.\n- Still accepts FIREBASE_SERVICE_ACCOUNT_B64.\n- This fixes runner auth errors when B64 is misconfigured by allowing a raw JSON secret.\n\nAfter merge, set one of:\n- FIREBASE_SERVICE_ACCOUNT_B64 (one-line base64 of the JSON)\n- or FIREBASE_SERVICE_ACCOUNT (full JSON).\nThen run the workflow manually to verify.