### PR TITLE
Retention: daily cleanup + docs

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,42 @@
+name: Cleanup Data Retention
+
+on:
+  schedule:
+    - cron: '9 3 * * *' # daily at 03:09 UTC
+  workflow_dispatch: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Prepare service account (raw JSON)
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT}" ]; then
+            printf "%s" "${FIREBASE_SERVICE_ACCOUNT}" > "$RUNNER_TEMP/sa.json"
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa.json" >> "$GITHUB_ENV"
+          fi
+
+      - name: Run cleanup
+        env:
+          FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          IDV_TTL_DAYS: '90'
+          REPORTS_TTL_DAYS: '180'
+        run: node scripts/ops/cleanup.mjs
+

--- a/docs/ops/data-retention.md
+++ b/docs/ops/data-retention.md
@@ -1,0 +1,46 @@
+# Data Minimization & Retention
+
+This project practices data minimization — we only store what’s needed to provide the service, and we retain it for limited periods.
+
+## Automated Cleanup (TTL)
+
+We provide a GitHub Actions workflow and script to clean up old records:
+- `idv_attempts`: deleted after 90 days (configurable via `IDV_TTL_DAYS`).
+- `reports` with `status == "resolved"`: deleted after 180 days (configurable via `REPORTS_TTL_DAYS`).
+
+Script: `scripts/ops/cleanup.mjs`
+Workflow: `.github/workflows/cleanup.yml` (runs daily at 03:09 UTC)
+
+Authentication for the script:
+- Set one of these repo secrets:
+  - `FIREBASE_SERVICE_ACCOUNT_B64`: base64 of the full service account JSON
+  - or `FIREBASE_SERVICE_ACCOUNT`: full JSON as a raw secret (the workflow writes it to `$GOOGLE_APPLICATION_CREDENTIALS`)
+
+You can also run locally:
+```
+GOOGLE_APPLICATION_CREDENTIALS=/abs/path/sa.json \
+IDV_TTL_DAYS=90 REPORTS_TTL_DAYS=180 \
+node scripts/ops/cleanup.mjs
+```
+
+## Firestore TTL Policy (Optional)
+
+Firestore supports server-side TTL. Consider enabling TTL policies as a complement or alternative:
+- For `idv_attempts`, set TTL on field `timestamp`.
+- For `reports`, set TTL on field `resolvedAt` for `status == "resolved"`.
+
+TTL is configured in the Google Cloud Console or via `gcloud`:
+- https://cloud.google.com/firestore/docs/ttl/overview
+
+Note: We kept an app-level cleanup script to avoid coupling TTL to environment-specific console settings and to allow nuanced logic.
+
+## Encryption at Rest & In Transit
+
+- All data in Firestore is encrypted at rest by Google Cloud using industry-standard encryption.
+- All network access to the app and APIs uses TLS (HTTPS).
+- If we add application-layer encryption (e.g., encrypting certain fields client-side), we will document:
+  - The fields encrypted
+  - Key management approach
+  - Rotation procedures and recovery
+
+At present, we rely on Firebase/Google Cloud’s encryption at rest and TLS in transit.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -16,6 +16,22 @@
         { "fieldPath": "type", "order": "ASCENDING" },
         { "fieldPath": "createdBy", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionId": "reports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "resolvedAt", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionId": "reports",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/scripts/ops/cleanup.mjs
+++ b/scripts/ops/cleanup.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Data minimization cleanup:
+// - Delete idv_attempts older than IDV_TTL_DAYS (default 90)
+// - Delete reports with status == 'resolved' older than REPORTS_TTL_DAYS (default 180) by resolvedAt, then fallback to createdAt
+// Usage: node scripts/ops/cleanup.mjs
+// Auth: FIREBASE_SERVICE_ACCOUNT_B64 or FIREBASE_SERVICE_ACCOUNT or GOOGLE_APPLICATION_CREDENTIALS
+
+import admin from 'firebase-admin';
+
+function initAdmin() {
+  if (admin.apps.length) return admin.app();
+  const b64 = process.env.FIREBASE_SERVICE_ACCOUNT_B64;
+  const jsonStr = process.env.FIREBASE_SERVICE_ACCOUNT;
+  let keyJson;
+  if (b64) {
+    try {
+      const decoded = Buffer.from(b64, 'base64').toString('utf8').trim();
+      keyJson = decoded.startsWith('{') ? JSON.parse(decoded) : JSON.parse(b64);
+    } catch { /* fallthrough */ }
+  }
+  if (!keyJson && jsonStr) {
+    try { keyJson = JSON.parse(jsonStr); } catch {}
+  }
+  if (keyJson) admin.initializeApp({ credential: admin.credential.cert(keyJson) });
+  else admin.initializeApp({ credential: admin.credential.applicationDefault() });
+  return admin.app();
+}
+
+function daysAgo(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+async function deleteQuery(db, q, label, limitBatch = 300) {
+  const snap = await q.get();
+  if (snap.empty) return 0;
+  let count = 0;
+  const chunks = [];
+  let batch = db.batch();
+  let i = 0;
+  for (const doc of snap.docs) {
+    batch.delete(doc.ref);
+    i++; count++;
+    if (i >= limitBatch) { chunks.push(batch.commit()); batch = db.batch(); i = 0; }
+  }
+  if (i > 0) chunks.push(batch.commit());
+  await Promise.all(chunks);
+  console.log(`[cleanup] Deleted ${count} from ${label}`);
+  return count;
+}
+
+async function main() {
+  const app = initAdmin();
+  const db = app.firestore();
+  const IDV_TTL_DAYS = parseInt(process.env.IDV_TTL_DAYS || '90', 10);
+  const REPORTS_TTL_DAYS = parseInt(process.env.REPORTS_TTL_DAYS || '180', 10);
+
+  const idvCutoff = daysAgo(IDV_TTL_DAYS);
+  const reportsCutoff = daysAgo(REPORTS_TTL_DAYS);
+
+  // idv_attempts by timestamp
+  try {
+    await deleteQuery(db, db.collection('idv_attempts').where('timestamp', '<', idvCutoff), 'idv_attempts');
+  } catch (e) {
+    console.error('[cleanup] idv_attempts failed:', e.message || e);
+  }
+
+  // reports resolved by resolvedAt
+  try {
+    // Prefer resolvedAt when present
+    await deleteQuery(
+      db,
+      db.collection('reports').where('status', '==', 'resolved').where('resolvedAt', '<', reportsCutoff),
+      'reports(resolvedAt)'
+    );
+  } catch (e) {
+    console.warn('[cleanup] reports(resolvedAt) query failed or no index:', e.message || e);
+  }
+  try {
+    // Fallback by createdAt for resolved reports missing resolvedAt
+    await deleteQuery(
+      db,
+      db.collection('reports').where('status', '==', 'resolved').where('createdAt', '<', reportsCutoff),
+      'reports(createdAt)'
+    );
+  } catch (e) {
+    console.warn('[cleanup] reports(createdAt) query failed or no index:', e.message || e);
+  }
+
+  console.log('[cleanup] Done');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+


### PR DESCRIPTION
Implements data minimization/retention:\n\n- Cleanup script + daily workflow:\n  - scripts/ops/cleanup.mjs deletes idv_attempts >90d and resolved reports >180d (configurable)\n  - .github/workflows/cleanup.yml runs daily, supports both B64 and raw JSON service account\n- Indexes: adds Firestore composite indexes for reports cleanup\n- Docs: docs/ops/data-retention.md (how it works, TTL option, encryption at rest statement)\n\nAfter merge:\n- Ensure one of FIREBASE_SERVICE_ACCOUNT_B64 or FIREBASE_SERVICE_ACCOUNT is set in repo secrets.\n- (Optional) Adjust IDV_TTL_DAYS / REPORTS_TTL_DAYS in workflow env.
