### PR TITLE
Bot mitigation: App Check enforcement, rate limits, strict KYC for sensitive topics

### DIFF
--- a/src/components/topics/DebatePostCard.tsx
+++ b/src/components/topics/DebatePostCard.tsx
@@ -255,6 +255,7 @@ export function DebatePostCard({ statement }: DebateStatementCardProps) {
         appcheck: { title: 'Security Check Failed', description: 'App integrity verification failed. Refresh and try again.' },
         unauthorized: { title: 'Authentication Required', description: 'Please sign in again and retry.' },
         toxicity: { title: 'Content Blocked for Civility', description: 'Please rephrase to keep it respectful.' },
+        rate_limited: { title: 'Too Many Requests', description: 'You are posting too quickly. Please wait and try again.' },
       };
       const m = (code && map[code]) || { title: 'Failed to post question', description: 'Please try again.' };
       if (code === 'toxicity') {

--- a/src/components/topics/PostForm.tsx
+++ b/src/components/topics/PostForm.tsx
@@ -206,6 +206,10 @@ export function PostForm({ topic, onStatementCreated }: StatementFormProps) {
           title: 'Content Blocked for Civility',
           description: 'Please revise to keep it respectful and constructive.',
         },
+        rate_limited: {
+          title: 'Too Many Requests',
+          description: 'You are posting too quickly. Please slow down and try again shortly.',
+        },
       };
       const m = (code && map[code]) || {
         title: 'Failed to Submit Statement',

--- a/src/components/topics/ThreadPostForm.tsx
+++ b/src/components/topics/ThreadPostForm.tsx
@@ -159,6 +159,7 @@ export function ThreadPostForm({
         appcheck: { title: 'Security Check Failed', description: 'App integrity verification failed. Refresh and try again.' },
         unauthorized: { title: 'Authentication Required', description: 'Please sign in again and retry.' },
         toxicity: { title: 'Content Blocked for Civility', description: 'Please rephrase to keep it respectful.' },
+        rate_limited: { title: 'Too Many Requests', description: 'You are posting too quickly. Please wait and try again.' },
       };
       const m = (code && map[code]) || {
         title: `Failed to Submit ${type.charAt(0).toUpperCase() + type.slice(1)}`,

--- a/src/lib/client/statements.ts
+++ b/src/lib/client/statements.ts
@@ -35,9 +35,20 @@ export async function createStatement(
 ) {
   // Use API route to enforce server-side gates
   const token = await (await import('firebase/auth')).getAuth().currentUser?.getIdToken();
+  // Optional App Check token if configured
+  let appCheckToken: string | undefined = undefined;
+  try {
+    const { getToken } = await import('firebase/app-check');
+    const r = await getToken(undefined as any, false);
+    appCheckToken = r?.token;
+  } catch {}
   const res = await fetch('/api/statements/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(appCheckToken ? { 'X-Firebase-AppCheck': appCheckToken } : {}),
+    },
     body: JSON.stringify({ topicId, content, claimType, sourceUrl, aiAssisted }),
   });
   if (!res.ok) {

--- a/src/lib/client/threads.ts
+++ b/src/lib/client/threads.ts
@@ -24,9 +24,20 @@ export async function createThreadNode(data: {
 }): Promise<ThreadNode> {
   // Use API route to enforce server-side gates
   const token = await (await import('firebase/auth')).getAuth().currentUser?.getIdToken();
+  // Optional App Check token if configured
+  let appCheckToken: string | undefined = undefined;
+  try {
+    const { getToken } = await import('firebase/app-check');
+    const r = await getToken(undefined as any, false);
+    appCheckToken = r?.token;
+  } catch {}
   const res = await fetch('/api/threads/create', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(appCheckToken ? { 'X-Firebase-AppCheck': appCheckToken } : {}),
+    },
     body: JSON.stringify({
       topicId: data.topicId,
       statementId: data.statementId,

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -23,6 +23,11 @@ class SimpleRateLimiter {
 
 export const globalRateLimiter = new SimpleRateLimiter({ windowMs: 15_000, max: 30 });
 
+// Cross-endpoint posting limiter (statements + threads)
+// Tuned to be conservative but not block normal usage.
+export const postIpLimiter = new SimpleRateLimiter({ windowMs: 60_000, max: 20 }); // 20 ops/min per IP
+export const postUserLimiter = new SimpleRateLimiter({ windowMs: 60_000, max: 8 }); // 8 ops/min per user
+
 export function getClientKey(req: Request): string {
   try {
     // Use IP if available; fallback to user agent
@@ -33,4 +38,3 @@ export function getClientKey(req: Request): string {
     return 'unknown';
   }
 }
-


### PR DESCRIPTION
Implements bot mitigation per manifesto:\n\n- Enforce App Check on write APIs: server verifies X-Firebase-AppCheck (production), client attaches token if App Check configured.\n- Anomaly rate limits across statement/thread creation: per-IP and per-user shared limiters.\n- Optional strict KYC for sensitive topics: if topic.postingPolicy.requireVerified (or requireVerifiedNow/sensitive), grace is disabled; only verified users can post.\n\nGuidance included below for enabling App Check and configuring sensitive topics.\n\nFiles:\n- API: src/app/api/statements/create/route.ts, src/app/api/threads/create/route.ts\n- Client: src/lib/client/{statements,threads}.ts (attach App Check token)\n- Rate limiters: src/lib/rateLimit.ts\n- Toast mappings: PostForm, ThreadPostForm, DebatePostCard\n\nAfter merge: set NEXT_PUBLIC_RECAPTCHA_SITE_KEY and enable App Check on Firebase (steps in comment).