### PR TITLE
chore(ci): auto-delete merged branches; keep only main clean

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -1,0 +1,44 @@
+name: Cleanup merged branches
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 3 * * 0'
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const main = 'main'
+            const per_page = 100
+            let page = 1
+            const branches = []
+            while (true) {
+              const { data } = await github.rest.repos.listBranches({ owner: context.repo.owner, repo: context.repo.repo, per_page, page })
+              if (!data.length) break
+              branches.push(...data)
+              page++
+            }
+            for (const br of branches) {
+              const name = br.name
+              if (name === main) continue
+              if (br.protected) continue
+              try {
+                const cmp = await github.rest.repos.compareCommits({ owner: context.repo.owner, repo: context.repo.repo, base: name, head: main })
+                if (cmp.data.status === 'identical' || cmp.data.status === 'behind') {
+                  await github.rest.git.deleteRef({ owner: context.repo.owner, repo: context.repo.repo, ref: `heads/${name}` })
+                  core.info(`Deleted ${name}`)
+                } else {
+                  core.info(`Keeping ${name} (status ${cmp.data.status})`)
+                }
+              } catch (e) {
+                core.warning(`Skipping ${br.name}: ${e.message}`)
+              }
+            }


### PR DESCRIPTION
### Summary

Describe the change and why it’s needed.

### Checklist

- [ ] Build passes locally: `npm ci && npm run typecheck && npm run build`
- [ ] No client component imports server actions or `firebase-admin` (boundary check passes)
- [ ] Client calls server via API routes (e.g., `/api/search/suggest`), not server actions
- [ ] TypeScript types updated; no obvious `any` where avoidable
- [ ] Logging via `src/lib/logger.ts` (no scattered `console.log`)
- [ ] Firebase rules/indexes updated if data paths changed; docs updated
- [ ] `.env.example` updated if new env vars introduced
- [ ] System prompt invariants respected (see `docs/ai/system-prompt.md`)

### Testing / Verification

Include steps, screenshots, or notes to verify changes.

