### PR TITLE
feat(mobile): wire auth + App Check protected API flow

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,3 @@
+EXPO_PUBLIC_API_BASE_URL=https://dbaitr.com
+# Dev-only App Check debug token registered in Firebase Console
+EXPO_PUBLIC_APPCHECK_DEBUG_TOKEN=

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .expo
 .expo-shared
+.env
+google-services.json
+GoogleService-Info.plist

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,22 +1,48 @@
-# dbaitr mobile (Phase 1 scaffold)
+# dbaitr mobile
 
-This app is the foundation for native verification and mobile-first UX.
+React Native + Expo app for secure native verification and mobile-first UX.
 
-## Scope in Phase 1
+## Implemented in Phase 2
 
-- React Native + Expo project skeleton
-- Route structure for in-app verification flow
-- Shared API contracts consumed from `packages/shared`
-- API base URL wiring (`EXPO_PUBLIC_API_BASE_URL`)
+- Native auth session wiring (`@react-native-firebase/auth`)
+- Native App Check activation and token acquisition (`@react-native-firebase/app-check`)
+- Protected API client that always sends:
+  - `X-Firebase-AppCheck`
+  - `Authorization: Bearer <idToken>` (unless explicitly anonymous)
+- Email-first auth flow:
+  - check email existence (`/api/auth/check-email`)
+  - route to sign in or sign up
+  - bootstrap user claims/profile via `/api/users/bootstrap`
+- Verification screen connected to backend:
+  - create challenge (`/api/idv/challenge`)
+  - refresh result (`/api/idv/result`)
 
-## Not implemented yet
+## Security notes
 
-- Firebase Auth session binding
-- Mobile App Check (App Attest / Play Integrity)
-- Native personhood verifier execution
-- Proof submission + dedup UX
+- The same backend protection model is used as web: `withAuth` + strict App Check + strict ID token.
+- Mobile never writes privileged fields directly; verification authority remains server-side.
 
-## Local setup
+## Prerequisites
+
+1. Add Firebase native config files (not committed):
+   - `apps/mobile/google-services.json`
+   - `apps/mobile/GoogleService-Info.plist`
+2. Enable App Check providers in Firebase Console:
+   - Android: Play Integrity
+   - iOS: App Attest (or DeviceCheck fallback)
+3. For local/dev testing, set `EXPO_PUBLIC_APPCHECK_DEBUG_TOKEN` and register the token in Firebase App Check Console.
+
+## Environment
+
+Create `apps/mobile/.env` from `.env.example`.
+
+Required:
+- `EXPO_PUBLIC_API_BASE_URL` (example: `https://dbaitr.com`)
+
+Optional (dev):
+- `EXPO_PUBLIC_APPCHECK_DEBUG_TOKEN`
+
+## Run
 
 ```bash
 cd apps/mobile
@@ -24,12 +50,4 @@ npm install
 npm run start
 ```
 
-Optional env vars:
-
-```bash
-EXPO_PUBLIC_API_BASE_URL=https://dbaitr.com
-```
-
-## Handoff model
-
-Web users will be redirected to this app for personhood verification. Verification completion and claim updates stay server-authoritative in the existing backend.
+Use a custom dev client (`expo-dev-client`) because native Firebase modules are used.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,14 +16,20 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.dbaitr.mobile"
+      "bundleIdentifier": "com.dbaitr.mobile",
+      "googleServicesFile": "./GoogleService-Info.plist"
     },
     "android": {
-      "package": "com.dbaitr.mobile"
+      "package": "com.dbaitr.mobile",
+      "googleServicesFile": "./google-services.json"
     },
     "plugins": [
+      "expo-dev-client",
       "expo-router",
-      "expo-secure-store"
+      "expo-secure-store",
+      "@react-native-firebase/app",
+      "@react-native-firebase/auth",
+      "@react-native-firebase/app-check"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,13 +1,16 @@
 import { Stack } from 'expo-router';
+import { AuthProvider } from '../src/auth/AuthProvider';
 
 export default function RootLayout() {
   return (
-    <Stack
-      screenOptions={{
-        headerStyle: { backgroundColor: '#101936' },
-        headerTintColor: '#fff',
-        contentStyle: { backgroundColor: '#f8fafc' },
-      }}
-    />
+    <AuthProvider>
+      <Stack
+        screenOptions={{
+          headerStyle: { backgroundColor: '#101936' },
+          headerTintColor: '#fff',
+          contentStyle: { backgroundColor: '#f8fafc' },
+        }}
+      />
+    </AuthProvider>
   );
 }

--- a/apps/mobile/app/auth.tsx
+++ b/apps/mobile/app/auth.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { router } from 'expo-router';
+import { Pressable, SafeAreaView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { checkEmailExists } from '../src/auth/api';
+import { useAuth } from '../src/auth/AuthProvider';
+
+export default function AuthScreen() {
+  const { user, error: authError, signIn, signUp } = useAuth();
+
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [fullName, setFullName] = React.useState('');
+  const [checking, setChecking] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [knownAccount, setKnownAccount] = React.useState<boolean | null>(null);
+  const [localError, setLocalError] = React.useState<string | null>(null);
+
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const checkEmail = React.useCallback(async () => {
+    setLocalError(null);
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
+      setLocalError('Enter a valid email.');
+      return;
+    }
+
+    setChecking(true);
+    try {
+      const result = await checkEmailExists(normalizedEmail);
+      if (!result?.ok) {
+        setLocalError(result?.error || 'Unable to check email right now.');
+        return;
+      }
+      setKnownAccount(!!result.exists);
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Unable to check email right now.');
+    } finally {
+      setChecking(false);
+    }
+  }, [normalizedEmail]);
+
+  const submit = React.useCallback(async () => {
+    setLocalError(null);
+    if (!normalizedEmail) {
+      setLocalError('Email is required.');
+      return;
+    }
+    if (!password || password.length < 8) {
+      setLocalError('Use a password with at least 8 characters.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (knownAccount) {
+        await signIn(normalizedEmail, password);
+      } else {
+        const name = fullName.trim();
+        if (name.length < 3 || !name.includes(' ')) {
+          setLocalError('Enter your full legal name.');
+          return;
+        }
+        await signUp(normalizedEmail, password, name);
+      }
+      router.replace('/');
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Authentication failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [fullName, knownAccount, normalizedEmail, password, signIn, signUp]);
+
+  if (user) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.card}>
+          <Text style={styles.title}>You are signed in.</Text>
+          <Text style={styles.body}>Continue to verification or return to the home screen.</Text>
+          <Pressable style={styles.button} onPress={() => router.replace('/')}>
+            <Text style={styles.buttonText}>Go Home</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Sign in to dbaitr</Text>
+        <Text style={styles.body}>We check your email first, then route to login or registration.</Text>
+
+        <TextInput
+          value={email}
+          autoCapitalize="none"
+          keyboardType="email-address"
+          placeholder="Email"
+          style={styles.input}
+          onChangeText={(value) => {
+            setEmail(value);
+            setKnownAccount(null);
+          }}
+        />
+
+        {knownAccount === null && (
+          <Pressable style={styles.button} disabled={checking} onPress={checkEmail}>
+            <Text style={styles.buttonText}>{checking ? 'Checking…' : 'Continue'}</Text>
+          </Pressable>
+        )}
+
+        {knownAccount !== null && (
+          <>
+            {!knownAccount && (
+              <TextInput
+                value={fullName}
+                autoCapitalize="words"
+                placeholder="Full legal name"
+                style={styles.input}
+                onChangeText={setFullName}
+              />
+            )}
+            <TextInput
+              value={password}
+              secureTextEntry
+              placeholder={knownAccount ? 'Password' : 'Create password'}
+              style={styles.input}
+              onChangeText={setPassword}
+            />
+            <Pressable style={styles.button} disabled={submitting} onPress={submit}>
+              <Text style={styles.buttonText}>
+                {submitting ? 'Please wait…' : knownAccount ? 'Sign In' : 'Create Account'}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.linkButton]}
+              onPress={() => {
+                setKnownAccount(null);
+                setPassword('');
+                setFullName('');
+                setLocalError(null);
+              }}
+            >
+              <Text style={styles.linkText}>Use a different email</Text>
+            </Pressable>
+          </>
+        )}
+
+        {(localError || authError) && <Text style={styles.errorText}>{localError || authError}</Text>}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f8fafc',
+    padding: 20,
+    justifyContent: 'center',
+  },
+  card: {
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    padding: 20,
+    gap: 12,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#0f172a',
+  },
+  body: {
+    fontSize: 14,
+    color: '#334155',
+    lineHeight: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: '#0f172a',
+    backgroundColor: '#fff',
+  },
+  button: {
+    borderRadius: 8,
+    backgroundColor: '#1d4ed8',
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  linkButton: {
+    alignItems: 'center',
+    paddingVertical: 6,
+  },
+  linkText: {
+    color: '#1d4ed8',
+    fontWeight: '600',
+  },
+  errorText: {
+    color: '#b91c1c',
+    fontSize: 14,
+  },
+});

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,17 +1,37 @@
 import { Link } from 'expo-router';
-import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { useAuth } from '../src/auth/AuthProvider';
 
 export default function HomeScreen() {
+  const { initializing, user, profile, signOut } = useAuth();
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.card}>
         <Text style={styles.title}>dbaitr Mobile</Text>
         <Text style={styles.body}>
-          This is the mobile foundation. Personhood verification is designed to complete entirely in-app.
+          Native auth + App Check are now wired. Verification APIs use the same protected backend contract as web.
         </Text>
+        {initializing && <Text style={styles.meta}>Session: loading…</Text>}
+        {!initializing && !user && <Text style={styles.meta}>Session: signed out</Text>}
+        {!initializing && user && (
+          <Text style={styles.meta}>
+            Session: {profile?.fullName || user.email || 'signed in'} ({profile?.status || 'unknown'})
+          </Text>
+        )}
+        {!user && (
+          <Link href="/auth" style={styles.link}>
+            Continue to Sign In
+          </Link>
+        )}
         <Link href="/verify" style={styles.link}>
           Open Personhood Verification
         </Link>
+        {!!user && (
+          <Pressable style={styles.button} onPress={() => void signOut()}>
+            <Text style={styles.buttonText}>Sign Out</Text>
+          </Pressable>
+        )}
       </View>
     </SafeAreaView>
   );
@@ -49,5 +69,19 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: '#1d4ed8',
+  },
+  meta: {
+    fontSize: 13,
+    color: '#475569',
+  },
+  button: {
+    borderRadius: 8,
+    backgroundColor: '#0f172a',
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '600',
   },
 });

--- a/apps/mobile/app/verify.tsx
+++ b/apps/mobile/app/verify.tsx
@@ -1,29 +1,112 @@
-import { useMemo } from 'react';
-import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
-import type { IdvChallengeResponse } from '@dbaitr/shared/idv';
-
-const PLACEHOLDER_CHALLENGE: IdvChallengeResponse = {
-  ok: true,
-  provider: 'self_openpassport',
-  challengeId: 'phase-1-placeholder',
-  challenge: 'phase-1-placeholder',
-  expiresAtMs: Date.now() + 10 * 60 * 1000,
-  verificationUrl: null,
-};
+import React from 'react';
+import * as Linking from 'expo-linking';
+import { Link } from 'expo-router';
+import { Pressable, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import type { IdvChallengeResponse, IdvResultResponse } from '@dbaitr/shared/idv';
+import { useAuth } from '../src/auth/AuthProvider';
+import { createIdvChallenge, fetchIdvResult } from '../src/idvApi';
 
 export default function VerifyScreen() {
-  const expiresAt = useMemo(() => new Date(PLACEHOLDER_CHALLENGE.expiresAtMs).toISOString(), []);
+  const { user, profile } = useAuth();
+  const [challenge, setChallenge] = React.useState<IdvChallengeResponse | null>(null);
+  const [result, setResult] = React.useState<IdvResultResponse | null>(null);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createChallenge = React.useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await createIdvChallenge();
+      if (!response?.ok) {
+        setError('Unable to create verification challenge.');
+        return;
+      }
+      setChallenge(response);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to create verification challenge.');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const refreshResult = React.useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetchIdvResult();
+      if (!response) {
+        setError('Unable to fetch verification status.');
+        return;
+      }
+      setResult(response);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'Unable to fetch verification status.');
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!challenge || result?.approved) return;
+    const timer = setInterval(() => {
+      void refreshResult();
+    }, 10_000);
+    return () => clearInterval(timer);
+  }, [challenge, refreshResult, result?.approved]);
+
+  if (!user) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.card}>
+          <Text style={styles.title}>Native Verification</Text>
+          <Text style={styles.body}>Sign in first. Verification endpoints require ID token and App Check.</Text>
+          <Link href="/auth" style={styles.link}>Go to Sign In</Link>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.card}>
-        <Text style={styles.title}>Native Verification (Phase 1)</Text>
+        <Text style={styles.title}>Native Verification</Text>
         <Text style={styles.body}>
-          This screen is intentionally a scaffold. In Phase 2+, it will create a signed challenge via API,
-          launch the in-app verifier flow, and submit proof to your self-hosted backend.
+          Status: {profile?.kycVerified ? 'Already verified' : 'Not verified'}
         </Text>
-        <Text style={styles.meta}>Provider: {PLACEHOLDER_CHALLENGE.provider}</Text>
-        <Text style={styles.meta}>Challenge expires: {expiresAt}</Text>
+
+        <Pressable style={styles.button} disabled={busy} onPress={() => void createChallenge()}>
+          <Text style={styles.buttonText}>{busy ? 'Please wait…' : 'Generate Challenge'}</Text>
+        </Pressable>
+
+        {!!challenge && (
+          <View style={styles.panel}>
+            <Text style={styles.meta}>Challenge ID: {challenge.challengeId}</Text>
+            <Text style={styles.meta}>Expires: {new Date(challenge.expiresAtMs).toLocaleString()}</Text>
+            {challenge.verificationUrl ? (
+              <Pressable style={styles.secondaryButton} onPress={() => void Linking.openURL(challenge.verificationUrl || '')}>
+                <Text style={styles.secondaryButtonText}>Open Verification App</Text>
+              </Pressable>
+            ) : (
+              <Text style={styles.meta}>No verification URL returned.</Text>
+            )}
+          </View>
+        )}
+
+        <Pressable style={styles.secondaryButton} disabled={busy} onPress={() => void refreshResult()}>
+          <Text style={styles.secondaryButtonText}>Refresh Verification Status</Text>
+        </Pressable>
+
+        {!!result && (
+          <View style={styles.panel}>
+            <Text style={styles.meta}>Approved: {result.approved ? 'Yes' : 'No'}</Text>
+            <Text style={styles.meta}>Reason: {result.reason || 'none'}</Text>
+            <Text style={styles.meta}>Provider: {result.provider || 'unknown'}</Text>
+            <Text style={styles.meta}>Verified At: {result.verifiedAt || 'n/a'}</Text>
+          </View>
+        )}
+
+        {!!error && <Text style={styles.error}>{error}</Text>}
       </View>
     </SafeAreaView>
   );
@@ -37,11 +120,11 @@ const styles = StyleSheet.create({
   },
   card: {
     borderRadius: 12,
-    backgroundColor: '#ffffff',
-    padding: 20,
+    backgroundColor: '#fff',
     borderWidth: 1,
     borderColor: '#e2e8f0',
-    gap: 10,
+    padding: 20,
+    gap: 12,
   },
   title: {
     fontSize: 22,
@@ -53,8 +136,47 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: '#334155',
   },
+  panel: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 10,
+    padding: 12,
+    gap: 8,
+  },
   meta: {
     fontSize: 13,
     color: '#475569',
+  },
+  button: {
+    borderRadius: 8,
+    backgroundColor: '#1d4ed8',
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#1d4ed8',
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  secondaryButtonText: {
+    color: '#1d4ed8',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  link: {
+    color: '#1d4ed8',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  error: {
+    color: '#b91c1c',
+    fontSize: 14,
   },
 });

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,8 +11,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-native-firebase/app": "^21.14.0",
+    "@react-native-firebase/app-check": "^21.14.0",
+    "@react-native-firebase/auth": "^21.14.0",
     "@dbaitr/shared": "file:../../packages/shared",
     "expo": "~53.0.0",
+    "expo-dev-client": "~5.2.4",
     "expo-linking": "~7.0.0",
     "expo-router": "~5.0.0",
     "expo-secure-store": "~14.0.0",

--- a/apps/mobile/src/auth/AuthProvider.tsx
+++ b/apps/mobile/src/auth/AuthProvider.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import type { BootstrappedProfile } from '@dbaitr/shared/auth';
+import type { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import {
+  ensureNativeAppCheck,
+  getAppCheckInitError,
+  getCurrentUser,
+  registerWithEmailPassword,
+  signInWithEmailPassword,
+  signOutCurrentUser,
+  subscribeAuthState,
+} from '../firebase/native';
+import { bootstrapUser } from './api';
+
+type AuthContextValue = {
+  initializing: boolean;
+  user: FirebaseAuthTypes.User | null;
+  profile: BootstrappedProfile | null;
+  error: string | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string, fullName: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  refreshProfile: () => Promise<void>;
+};
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined);
+
+function normalizeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error || 'unknown_error');
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [initializing, setInitializing] = React.useState(true);
+  const [user, setUser] = React.useState<FirebaseAuthTypes.User | null>(null);
+  const [profile, setProfile] = React.useState<BootstrappedProfile | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const bootstrapProfileForUser = React.useCallback(
+    async (actor: FirebaseAuthTypes.User | null, opts?: { fullName?: string }) => {
+      if (!actor) {
+        setProfile(null);
+        return;
+      }
+      const fullName = String(opts?.fullName || actor.displayName || '').trim() || undefined;
+      const result = await bootstrapUser(fullName);
+      if (!result?.ok || !result.profile) {
+        const reason = result?.error || 'bootstrap_failed';
+        setError(reason);
+        setProfile(null);
+        return;
+      }
+      setError(null);
+      setProfile(result.profile);
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    let mounted = true;
+    let unsubscribe: (() => void) | null = null;
+
+    (async () => {
+      try {
+        await ensureNativeAppCheck();
+      } catch {
+        const reason = getAppCheckInitError() || 'appcheck_init_failed';
+        if (mounted) setError(reason);
+      }
+
+      unsubscribe = subscribeAuthState(async (nextUser) => {
+        if (!mounted) return;
+        setUser(nextUser);
+        if (!nextUser) {
+          setProfile(null);
+          setInitializing(false);
+          return;
+        }
+        try {
+          await bootstrapProfileForUser(nextUser);
+        } finally {
+          if (mounted) setInitializing(false);
+        }
+      });
+    })();
+
+    return () => {
+      mounted = false;
+      if (unsubscribe) unsubscribe();
+    };
+  }, [bootstrapProfileForUser]);
+
+  const signIn = React.useCallback(async (email: string, password: string) => {
+    setError(null);
+    await signInWithEmailPassword(email, password);
+    await bootstrapProfileForUser(getCurrentUser());
+  }, [bootstrapProfileForUser]);
+
+  const signUp = React.useCallback(async (email: string, password: string, fullName: string) => {
+    setError(null);
+    await registerWithEmailPassword(email, password, fullName);
+    await bootstrapProfileForUser(getCurrentUser(), { fullName });
+  }, [bootstrapProfileForUser]);
+
+  const signOut = React.useCallback(async () => {
+    await signOutCurrentUser();
+    setProfile(null);
+  }, []);
+
+  const refreshProfile = React.useCallback(async () => {
+    await bootstrapProfileForUser(user);
+  }, [bootstrapProfileForUser, user]);
+
+  const value = React.useMemo<AuthContextValue>(
+    () => ({ initializing, user, profile, error, signIn, signUp, signOut, refreshProfile }),
+    [initializing, user, profile, error, signIn, signUp, signOut, refreshProfile]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = React.useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/apps/mobile/src/auth/api.ts
+++ b/apps/mobile/src/auth/api.ts
@@ -1,0 +1,29 @@
+import type { BootstrapResponse, CheckEmailResponse, MeResponse } from '@dbaitr/shared/auth';
+import { mobileApiFetch, readJsonSafe } from '../http/apiFetch';
+
+export async function checkEmailExists(email: string): Promise<CheckEmailResponse | null> {
+  const res = await mobileApiFetch('/api/auth/check-email', {
+    method: 'POST',
+    allowAnonymous: true,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+  return readJsonSafe<CheckEmailResponse>(res);
+}
+
+export async function bootstrapUser(fullName?: string): Promise<BootstrapResponse | null> {
+  const body = fullName ? JSON.stringify({ fullName }) : '{}';
+  const res = await mobileApiFetch('/api/users/bootstrap', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body,
+  });
+  return readJsonSafe<BootstrapResponse>(res);
+}
+
+export async function fetchCurrentProfile(): Promise<MeResponse | null> {
+  const res = await mobileApiFetch('/api/users/me', {
+    method: 'GET',
+  });
+  return readJsonSafe<MeResponse>(res);
+}

--- a/apps/mobile/src/config.ts
+++ b/apps/mobile/src/config.ts
@@ -1,7 +1,5 @@
-const DEFAULT_API_BASE = 'https://dbaitr.com';
+import { getMobileEnv } from './env';
 
 export function getApiBaseUrl(): string {
-  const envUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
-  if (envUrl && /^https?:\/\//.test(envUrl)) return envUrl;
-  return DEFAULT_API_BASE;
+  return getMobileEnv().apiBaseUrl;
 }

--- a/apps/mobile/src/env.ts
+++ b/apps/mobile/src/env.ts
@@ -1,0 +1,21 @@
+const DEFAULT_API_BASE = 'https://dbaitr.com';
+
+function normalizeApiBaseUrl(value: string | undefined): string {
+  const raw = String(value || '').trim();
+  if (!raw) return DEFAULT_API_BASE;
+  if (!/^https?:\/\//i.test(raw)) return DEFAULT_API_BASE;
+  return raw.replace(/\/$/, '');
+}
+
+export interface MobileEnv {
+  apiBaseUrl: string;
+  appCheckDebugToken: string | null;
+}
+
+export function getMobileEnv(): MobileEnv {
+  const appCheckDebugToken = String(process.env.EXPO_PUBLIC_APPCHECK_DEBUG_TOKEN || '').trim() || null;
+  return {
+    apiBaseUrl: normalizeApiBaseUrl(process.env.EXPO_PUBLIC_API_BASE_URL),
+    appCheckDebugToken,
+  };
+}

--- a/apps/mobile/src/firebase/native.ts
+++ b/apps/mobile/src/firebase/native.ts
@@ -1,0 +1,101 @@
+import appCheck from '@react-native-firebase/app-check';
+import auth, { type FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { getMobileEnv } from '../env';
+
+let appCheckInitPromise: Promise<void> | null = null;
+let appCheckInitError: string | null = null;
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error || 'unknown_error');
+}
+
+export async function ensureNativeAppCheck(): Promise<void> {
+  if (appCheckInitPromise) return appCheckInitPromise;
+
+  appCheckInitPromise = (async () => {
+    const env = getMobileEnv();
+    const debugToken = env.appCheckDebugToken || undefined;
+    const instance = appCheck() as any;
+    const candidates: Array<() => Promise<unknown>> = debugToken
+      ? [
+          () => Promise.resolve(instance.activate(debugToken, true)),
+          () => Promise.resolve(instance.activate(undefined, undefined, true)),
+          () => Promise.resolve(instance.activate()),
+        ]
+      : [
+          () => Promise.resolve(instance.activate(undefined, true)),
+          () => Promise.resolve(instance.activate(undefined, undefined, true)),
+          () => Promise.resolve(instance.activate()),
+        ];
+
+    let lastError: unknown = null;
+    let activated = false;
+    for (const run of candidates) {
+      try {
+        await run();
+        activated = true;
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (!activated) {
+      throw lastError || new Error('appcheck_activate_failed');
+    }
+    appCheckInitError = null;
+  })();
+
+  try {
+    await appCheckInitPromise;
+  } catch (error) {
+    appCheckInitError = errorMessage(error);
+    appCheckInitPromise = null;
+    throw error;
+  }
+}
+
+export function getAppCheckInitError(): string | null {
+  return appCheckInitError;
+}
+
+export async function getNativeAppCheckToken(forceRefresh = false): Promise<string | null> {
+  try {
+    await ensureNativeAppCheck();
+    const result = await appCheck().getToken(forceRefresh);
+    return result?.token || null;
+  } catch {
+    return null;
+  }
+}
+
+export function subscribeAuthState(listener: (user: FirebaseAuthTypes.User | null) => void): () => void {
+  return auth().onAuthStateChanged(listener);
+}
+
+export function getCurrentUser(): FirebaseAuthTypes.User | null {
+  return auth().currentUser;
+}
+
+export async function getCurrentIdToken(forceRefresh = false): Promise<string | null> {
+  const user = auth().currentUser;
+  if (!user) return null;
+  return user.getIdToken(forceRefresh);
+}
+
+export async function signInWithEmailPassword(email: string, password: string) {
+  return auth().signInWithEmailAndPassword(email.trim(), password);
+}
+
+export async function registerWithEmailPassword(email: string, password: string, fullName: string) {
+  const cred = await auth().createUserWithEmailAndPassword(email.trim(), password);
+  const cleanName = fullName.trim();
+  if (cleanName) {
+    await cred.user.updateProfile({ displayName: cleanName });
+  }
+  return cred;
+}
+
+export async function signOutCurrentUser() {
+  await auth().signOut();
+}

--- a/apps/mobile/src/http/apiFetch.ts
+++ b/apps/mobile/src/http/apiFetch.ts
@@ -1,0 +1,70 @@
+import { getApiBaseUrl } from '../config';
+import { getCurrentIdToken, getNativeAppCheckToken } from '../firebase/native';
+
+type MobileApiFetchOptions = RequestInit & {
+  allowAnonymous?: boolean;
+};
+
+function resolveUrl(input: string): string {
+  if (/^https?:\/\//i.test(input)) return input;
+  const base = getApiBaseUrl();
+  const path = input.startsWith('/') ? input : `/${input}`;
+  return `${base}${path}`;
+}
+
+function setHeader(headers: Headers, key: string, value: string) {
+  headers.set(key, value);
+}
+
+async function buildAuthHeaders(headers: Headers, force = false) {
+  const appCheck = await getNativeAppCheckToken(force);
+  if (appCheck) setHeader(headers, 'X-Firebase-AppCheck', appCheck);
+
+  const idToken = await getCurrentIdToken(force);
+  if (idToken) setHeader(headers, 'Authorization', `Bearer ${idToken}`);
+
+  return {
+    hasAppCheck: !!appCheck,
+    hasIdToken: !!idToken,
+  };
+}
+
+export async function mobileApiFetch(input: string, init?: MobileApiFetchOptions): Promise<Response> {
+  const options = init || {};
+  const headers = new Headers(options.headers || {});
+  const allowAnonymous = options.allowAnonymous === true;
+
+  const first = await buildAuthHeaders(headers, false);
+  if (!first.hasAppCheck) {
+    const error = new Error('Missing App Check token');
+    // @ts-expect-error Runtime code for caller classification
+    error.code = 'unauthenticated_appcheck';
+    throw error;
+  }
+  if (!allowAnonymous && !first.hasIdToken) {
+    const error = new Error('Missing auth token');
+    // @ts-expect-error Runtime code for caller classification
+    error.code = 'unauthenticated';
+    throw error;
+  }
+
+  const requestInit: RequestInit = { ...options, headers };
+  const targetUrl = resolveUrl(input);
+  const res = await fetch(targetUrl, requestInit);
+  if (res.status !== 401) return res;
+
+  const retryHeaders = new Headers(options.headers || {});
+  const retry = await buildAuthHeaders(retryHeaders, true);
+  if (!retry.hasAppCheck) return res;
+  if (!allowAnonymous && !retry.hasIdToken) return res;
+
+  return fetch(targetUrl, { ...options, headers: retryHeaders });
+}
+
+export async function readJsonSafe<T>(res: Response): Promise<T | null> {
+  try {
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/src/idvApi.ts
+++ b/apps/mobile/src/idvApi.ts
@@ -1,26 +1,20 @@
 import type { IdvChallengeResponse, IdvResultResponse } from '@dbaitr/shared/idv';
-import { getApiBaseUrl } from './config';
+import { mobileApiFetch, readJsonSafe } from './http/apiFetch';
 
-export async function fetchIdvResult(idToken: string): Promise<IdvResultResponse> {
-  const res = await fetch(`${getApiBaseUrl()}/api/idv/result`, {
+export async function fetchIdvResult(): Promise<IdvResultResponse | null> {
+  const res = await mobileApiFetch('/api/idv/result', {
     method: 'POST',
-    headers: {
-      authorization: `Bearer ${idToken}`,
-      'content-type': 'application/json',
-    },
+    headers: { 'content-type': 'application/json' },
     body: '{}',
   });
-  return (await res.json()) as IdvResultResponse;
+  return readJsonSafe<IdvResultResponse>(res);
 }
 
-export async function createIdvChallenge(idToken: string): Promise<IdvChallengeResponse> {
-  const res = await fetch(`${getApiBaseUrl()}/api/idv/challenge`, {
+export async function createIdvChallenge(): Promise<IdvChallengeResponse | null> {
+  const res = await mobileApiFetch('/api/idv/challenge', {
     method: 'POST',
-    headers: {
-      authorization: `Bearer ${idToken}`,
-      'content-type': 'application/json',
-    },
+    headers: { 'content-type': 'application/json' },
     body: '{}',
   });
-  return (await res.json()) as IdvChallengeResponse;
+  return readJsonSafe<IdvChallengeResponse>(res);
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Docs Index
 - claims-lifecycle.md — How claims are updated and clients refresh tokens.
 - personhood-verification.md — Proof-based human verification architecture, dedup model, provider contract, and test checklist.
 - mobile-architecture.md — Web + React Native split, trust boundaries, and phased rollout for in-app verification.
+- mobile-auth-appcheck.md — Mobile Firebase Auth + App Check setup, runtime path, and troubleshooting.
 - live-debates.md — YouTube integration flows: create, bind, ingest (fast-path), transition (preflight), poll/reconcile.
 - live-chat.md — Live chat data model and presence (Firestore + RTDB), API-only writes.
 - ops/data-retention.md — Data minimization and retention policy (including ID verification storage posture).

--- a/docs/appcheck-policy.md
+++ b/docs/appcheck-policy.md
@@ -35,3 +35,4 @@ Acceptance: Policy aligns with current code and Console config
 - Init order: `initAppCheckIfConfigured()` runs in the app shell before any feature initializes Firestore. Our `getDb()` singleton also calls `ensureAppCheck()` as a safety net.
 - Enforcement: Protected API routes require App Check headers via `withAuth`. Client SDK calls (Firestore/Storage) include App Check automatically once initialized.
 - Domains: Localhost and apphosting preview domains are allowed in Console. Production domains are restricted.
+- Mobile: React Native app uses `@react-native-firebase/app-check` and injects `X-Firebase-AppCheck` in every protected API call; see `docs/mobile-auth-appcheck.md`.

--- a/docs/mobile-architecture.md
+++ b/docs/mobile-architecture.md
@@ -44,9 +44,14 @@ Acceptance: Mobile scaffold and shared contracts exist, CI validates foundation,
   - mobile scaffold and shared package foundation
   - CI foundation guard
   - architecture docs for future implementation
-- Phase 2:
+- Phase 2 (implemented baseline):
   - Firebase auth + secure session bootstrap in mobile
-  - mobile App Check wiring
+  - mobile App Check wiring and protected API header injection
+  - implemented in:
+    - `apps/mobile/src/firebase/native.ts`
+    - `apps/mobile/src/http/apiFetch.ts`
+    - `apps/mobile/src/auth/AuthProvider.tsx`
+    - `apps/mobile/app/auth.tsx`
 - Phase 3:
   - web-to-mobile handoff tokens and deep link flow
 - Phase 4:

--- a/docs/mobile-auth-appcheck.md
+++ b/docs/mobile-auth-appcheck.md
@@ -1,0 +1,60 @@
+Version: 2026.02
+Last updated: 2026-02-15
+Owner: Platform Engineering
+Non-negotiables:
+- Mobile protected calls must include both App Check and ID token headers
+- Verification authority remains server-only (`withAuth` routes)
+- No privileged client-side writes
+Acceptance: Mobile app has auth + App Check bootstrap and a reproducible setup checklist
+
+# Mobile Auth + App Check Setup
+
+## What this enables
+
+- Mobile users can authenticate natively.
+- Mobile calls to protected APIs satisfy backend requirements:
+  - `X-Firebase-AppCheck`
+  - `Authorization: Bearer <id token>`
+- Mobile can bootstrap profile/claims and use IDV endpoints.
+
+## Required Firebase setup
+
+1. Create/register iOS and Android app entries in Firebase for this app.
+2. Download native config files and place locally (do not commit):
+   - `apps/mobile/google-services.json`
+   - `apps/mobile/GoogleService-Info.plist`
+3. Enable App Check providers:
+   - Android: Play Integrity
+   - iOS: App Attest (or DeviceCheck fallback)
+
+## Dev setup
+
+1. Register an App Check debug token in Firebase Console.
+2. Set in `apps/mobile/.env`:
+   - `EXPO_PUBLIC_APPCHECK_DEBUG_TOKEN=<token>`
+3. Set API base URL:
+   - `EXPO_PUBLIC_API_BASE_URL=https://dbaitr.com`
+
+## Runtime path
+
+- Auth flow:
+  - `POST /api/auth/check-email` (anonymous + App Check)
+  - Firebase auth sign-in/sign-up
+  - `POST /api/users/bootstrap` (App Check + ID token)
+- Verification flow:
+  - `POST /api/idv/challenge`
+  - `POST /api/idv/result`
+
+## Troubleshooting
+
+- `401 unauthenticated_appcheck`:
+  - App Check not activated, provider misconfigured, or debug token missing/not registered.
+- `401 unauthenticated`:
+  - User not signed in or ID token missing/expired.
+- `422 full_name_required` on bootstrap:
+  - Registration must provide full legal name.
+
+## Next phase
+
+- Add web-to-mobile secure handoff tokens and deep-link session transfer.
+- Integrate in-app proof execution path (native verifier) and proof submit endpoint usage.

--- a/docs/personhood-verification.md
+++ b/docs/personhood-verification.md
@@ -95,6 +95,7 @@ Phase 1 scaffold is tracked in:
 - `apps/mobile/**`
 - `packages/shared/**`
 - `/docs/mobile-architecture.md`
+- `/docs/mobile-auth-appcheck.md`
 
 ## Storage Model
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ops:apphosting:secrets": "bash scripts/ops/apphosting-secrets.sh",
     "admin:set-role": "node scripts/admin/set-role.mjs",
     "test:rules": "node scripts/tests/rules.test.mjs && node scripts/tests/api-security.test.mjs",
+    "mobile:install": "npm --prefix apps/mobile install",
     "mobile:start": "npm --prefix apps/mobile run start",
     "mobile:typecheck": "npm --prefix apps/mobile run typecheck"
   },

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -5,5 +5,6 @@ Shared contracts for web and mobile clients.
 Phase 1 scope:
 - auth/claims shape types
 - personhood verification request/response types
+- auth check-email/bootstrap/profile response shapes
 
 This package is intentionally type-first and runtime-light.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./auth": "./src/auth.ts",
     "./authz": "./src/authz.ts",
     "./idv": "./src/idv.ts"
   }

--- a/packages/shared/src/auth.ts
+++ b/packages/shared/src/auth.ts
@@ -1,0 +1,40 @@
+export interface CheckEmailRequest {
+  email: string;
+}
+
+export interface CheckEmailResponse {
+  ok: boolean;
+  exists: boolean;
+  methods?: string[];
+  source?: string;
+  confidence?: 'high' | 'medium' | 'low';
+  error?: string;
+}
+
+export type UserStatus = 'grace' | 'verified' | 'suspended' | 'banned' | 'deleted';
+
+export interface BootstrappedProfile {
+  uid: string;
+  email: string | null;
+  fullName: string;
+  role: string;
+  status: UserStatus;
+  kycVerified: boolean;
+  provider: 'password' | 'google' | 'apple' | 'unknown';
+}
+
+export interface BootstrapRequest {
+  fullName?: string;
+}
+
+export interface BootstrapResponse {
+  ok: boolean;
+  profile?: BootstrappedProfile;
+  error?: string;
+}
+
+export interface MeResponse {
+  ok: boolean;
+  profile: Record<string, unknown> | null;
+  error?: string;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
+export * from './auth';
 export * from './authz';
 export * from './idv';

--- a/scripts/checks/monorepo-foundation.mjs
+++ b/scripts/checks/monorepo-foundation.mjs
@@ -6,12 +6,19 @@ const root = process.cwd();
 
 const requiredPaths = [
   'apps/mobile/package.json',
+  'apps/mobile/.env.example',
+  'apps/mobile/app/auth.tsx',
   'apps/mobile/app/index.tsx',
   'apps/mobile/app/verify.tsx',
+  'apps/mobile/src/auth/AuthProvider.tsx',
+  'apps/mobile/src/http/apiFetch.ts',
+  'apps/mobile/src/firebase/native.ts',
   'packages/shared/package.json',
   'packages/shared/src/index.ts',
+  'packages/shared/src/auth.ts',
   'packages/shared/src/idv.ts',
   'docs/mobile-architecture.md',
+  'docs/mobile-auth-appcheck.md',
 ];
 
 const missing = requiredPaths.filter((rel) => !fs.existsSync(path.join(root, rel)));
@@ -42,6 +49,10 @@ if (deps['@dbaitr/shared'] !== 'file:../../packages/shared') {
 }
 if (!deps.expo || !deps['expo-router'] || !deps['react-native']) {
   console.error('Monorepo foundation check failed: mobile package must declare expo, expo-router, and react-native');
+  process.exit(1);
+}
+if (!deps['@react-native-firebase/app'] || !deps['@react-native-firebase/auth'] || !deps['@react-native-firebase/app-check']) {
+  console.error('Monorepo foundation check failed: mobile package must declare @react-native-firebase/app, /auth, and /app-check');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- add mobile native auth and app-check bootstrap modules for protected backend calls
- add mobile API client that always attaches X-Firebase-AppCheck and auth bearer token
- implement email-first auth screen (check-email -> sign in / register) and session bootstrap via /api/users/bootstrap
- connect mobile verification screen to /api/idv/challenge and /api/idv/result
- add shared auth contracts package exports and mobile auth/app-check setup docs
- extend monorepo foundation guard for phase-2 mobile files and dependencies

## Validation
- node scripts/checks/monorepo-foundation.mjs
- npm run -s typecheck
- npm run -s lint
- npm run -s apphosting:build

## Notes
- Mobile workspace dependencies are declared but not installed in this CI path (web deployment pipeline remains unchanged).
- Mobile runtime requires native Firebase config files and App Check provider setup described in docs/mobile-auth-appcheck.md.